### PR TITLE
support remote URIs

### DIFF
--- a/depth_calling/utilities.py
+++ b/depth_calling/utilities.py
@@ -50,9 +50,9 @@ def parse_gmm_file(gmm_file):
     return dpar_tmp
 
 
-def open_alignment_file(alignment_file, reference_fasta=None):
+def open_alignment_file(alignment_file, reference_fasta=None, index_filename=None):
     if alignment_file.endswith("cram"):
         return pysam.AlignmentFile(
-            alignment_file, "rc", reference_filename=reference_fasta
+            alignment_file, "rc", reference_filename=reference_fasta, index_filename=index_filename
         )
-    return pysam.AlignmentFile(alignment_file, "rb")
+    return pysam.AlignmentFile(alignment_file, "rb", index_filename=index_filename)

--- a/star_caller.py
+++ b/star_caller.py
@@ -511,6 +511,8 @@ def main():
     with open(manifest) as read_manifest:
         for line in read_manifest:
             manifest_entry = line.strip()
+            if manifest_entry.startswith('#'):
+                continue
             if '##idx##' in manifest_entry:
                 bam_name, index_name = manifest_entry.split('##idx##')
             else:


### PR DESCRIPTION
samtools 1.11 has some very useful features relates to urls and index files.
One of the few mentions I see of it is at 
https://github.com/samtools/samtools/blob/4fe33221082adceedfdbf525ced54c1a0883998c/NEWS#L63
But that fails to capture the scope of the enhancements.

One of the simplest and most immediately valuable changes allows

```
wget ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram
samtools view -H NA19239.final.cram
```

to be replaced by

```
samtools view -H ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram
```

which for large files is a HUGE benefit. This also works for ftp, http, https, s3 and gs style urls, which is a big win when working inside the amazon or google clouds. Do be aware that samtools doesn't yet benefit from IAM instance roles, so you may need to rely on ~/.aws/credentials or environment variables to specify credentials for non-public urls. see http://www.htslib.org/doc/htslib-s3-plugin.html for more details.

For cram files this also allows the reference genome to be determined at runtime and loaded dynamically (or from cache for performance).

Another benefit is when the index file is at a non-obvious location. This can now be communicated in a backwards compatible way by replacing a simple url with one that includes a '##idx##' delimiter.

samtools view  'https://example.com/path1/NA19239.final.cram##idx##https://example.com/path2/NA19239.final.cram.crai' chr22:1000000-1023000

Using these improvements with Cyrius necessitates passing the index location to pysam. This pull request achieves all of this in a fully backwards compatible way.

All of these lines are now valid manifest entries
```
/home/alice/crams/NA19239.final.cram
```
which would assume the index is at
/home/alice/crams/NA19239.final.cram.crai

or
```
/home/alice/crams/NA19239.final.cram##idx##/home/alice/indexes/NA19239.final.cram.crai
```

as well as remote url equivalents such as
```
ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram
```

```
ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram##idx##ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram.crai
```

mixed remote and local
```
ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR323/ERR3239454/NA19239.final.cram##idx##/home/alice/indexes/mylocal.cram.crai
```

```
s3://myprivatebucket/path/to/myfile.cram
```

```
s3://myprivatebucket/path/to/myfile.cram##idx##s3://myprivatebucket/index/path/myfile.cram.crai
```


The weakest aspect of this pull request is the use of a fairly simple check to determine if the file is local or remote. Currently this patch just checks for the existence of '://', but could easily be expanded to use techniques from https://stackoverflow.com/questions/22238090/validating-urls-in-python/22238205 or similar.

