### PR TITLE
improved support for index file at non-traditional locations

### DIFF
--- a/caller/call_variants.py
+++ b/caller/call_variants.py
@@ -224,7 +224,11 @@ def get_allele_counts_var42128936(bamfile_handle, genome):
         "38": ("chr22", 42128848, 42128978),
     }
     region = dregion[genome]
-    for read in bamfile_handle.fetch(region[0], region[1], region[2]):
+    try:
+        reads = bamfile_handle.fetch(region[0], region[1], region[2])
+    except ValueError:
+        reads = []
+    for read in reads:
         seq = read.query_sequence
         if good_read(read):
             if "TGGGGCGAAAGGGGCGAAAGGGGCGAAAGGGGCGT" in seq:

--- a/depth_calling/bin_count.py
+++ b/depth_calling/bin_count.py
@@ -100,7 +100,10 @@ def get_read_count(bamfile, region, mapq_cutoff=0):
     Keep duplicate reads.
     Keep unmapped reads with mapped mates.
     """
-    reads = bamfile.fetch(region[0], region[1], region[2])
+    try:
+        reads = bamfile.fetch(region[0], region[1], region[2])
+    except ValueError:
+        reads = []
     nreads = 0
     for read in reads:
         if (

--- a/depth_calling/bin_count.py
+++ b/depth_calling/bin_count.py
@@ -31,13 +31,13 @@ from .utilities import open_alignment_file
 MAD_CONSTANT = 1.4826
 
 
-def get_normed_depth(bamf, region_dic, nCores=1, reference=None, gc_correct=True):
+def get_normed_depth(bamf, region_dic, nCores=1, reference=None, gc_correct=True, index_filename=None):
     """
     Return the normalized depth values and coverage stats for a sample
     given a bam file
     """
     counts_for_normalization, gc_for_normalization, region_type_cn, read_length = count_reads_and_prepare_for_normalization(
-        bamf, region_dic, nCores, reference
+        bamf, region_dic, nCores, reference, index_filename=index_filename
     )
     normed_depth = normalize(
         counts_for_normalization,
@@ -167,13 +167,13 @@ def get_read_length(reads, number_to_count=2000):
 
 
 def count_reads_and_prepare_for_normalization(
-    bamf, region_dic, nCores=1, reference=None
+    bamf, region_dic, nCores=1, reference=None, index_filename=None
 ):
     """
     Return the normalized depth values and coverage stats for a sample
     given a bam file
     """
-    bamfile = open_alignment_file(bamf, reference)
+    bamfile = open_alignment_file(bamf, reference, index_filename=index_filename)
     # Store read counts in each interval
     counts_for_normalization = []
     gc_for_normalization = []
@@ -231,9 +231,9 @@ def partition(lst, n):
     return [lst[i::n] for i in range(n)]
 
 
-def get_normalization_region_values(l, bam, reference=None):
+def get_normalization_region_values(l, bam, reference=None, index_filename=None):
     """Perform read counting in a list of regions."""
-    bamfile = open_alignment_file(bam, reference)
+    bamfile = open_alignment_file(bam, reference, index_filename=index_filename)
     lcount = []
     for region in l:
         num_reads = get_read_count(bamfile, region)

--- a/depth_calling/bin_count.py
+++ b/depth_calling/bin_count.py
@@ -200,7 +200,11 @@ def count_reads_and_prepare_for_normalization(
             region_type_cn.setdefault(region_type, hap_cn)
 
     # Get read length from the last region
-    reads = bamfile.fetch(region[0], region[1], region[2])
+    try:
+        reads = bamfile.fetch(region[0], region[1], region[2])
+    except ValueError:
+        reads = []
+
     read_length = get_read_length(reads)
 
     lregion = [

--- a/depth_calling/bin_count.py
+++ b/depth_calling/bin_count.py
@@ -221,7 +221,8 @@ def count_reads_and_prepare_for_normalization(
                 counts_for_normalization.append(region_out[0])
                 gc_for_normalization.append(region_out[1])
 
-    bamfile.close()
+    # this closing was preventing some reuse of the bamfile
+    # bamfile.close()
 
     return counts_for_normalization, gc_for_normalization, region_type_cn, read_length
 

--- a/depth_calling/gmm.py
+++ b/depth_calling/gmm.py
@@ -121,7 +121,10 @@ class Gmm:
             )[0]
             prob.append(gauss_pmf * self.prior_state[i])
         sum_prob = float(sum(prob))
-        post_prob = [float(a) / sum_prob for a in prob]
+        if sum_prob == 0:
+            post_prob = [0 for a in prob]
+        else:
+            post_prob = [float(a) / sum_prob for a in prob]
         max_prob = max(post_prob)
         if max_prob >= post_cutoff:
             return post_prob.index(max_prob)

--- a/depth_calling/snp_count.py
+++ b/depth_calling/snp_count.py
@@ -117,15 +117,19 @@ def get_reads_by_region(
 
     for snp_position_ori in dsnp:
         snp_position = int(snp_position_ori.split("_")[0])
-        for pileupcolumn in bamfile_handle.pileup(
-            nchr,
-            snp_position - 1,
-            snp_position + 1,
-            truncate=True,
-            stepper="nofilter",
-            ignore_overlaps=False,
-            ignore_orphan=False,
-        ):
+        try:
+            column_generator = bamfile_handle.pileup(
+                nchr,
+                snp_position - 1,
+                snp_position + 1,
+                truncate=True,
+                stepper="nofilter",
+                ignore_overlaps=False,
+                ignore_orphan=False,
+            )
+        except ValueError:
+            column_generator = []
+        for pileupcolumn in column_generator:
             site_position = pileupcolumn.pos + 1
             if site_position == snp_position:
                 reg1_allele, reg2_allele = dsnp[snp_position_ori].split("_")

--- a/depth_calling/utilities.py
+++ b/depth_calling/utilities.py
@@ -62,8 +62,14 @@ def open_alignment_file(alignment_file, reference_fasta=None, index_filename=Non
                     print("was I supposed to assign the index? oops! I don't do that ... yet?")
             else:
                 print("was I supposed to assign the index? oops! I don't do that ... yet?")
-        return alignment_file
-    elif alignment_file.endswith("cram"):
+        # return alignment_file
+        print("@@1 reopening, but reusing seems possible if not unnecessarily closed()")
+        return pysam.AlignmentFile(
+            alignment_file.filename, "rc", reference_filename=alignment_file.reference_filename, index_filename=alignment_file.index_filename
+        )
+
+    elif alignment_file.endswith("cram") or (alignment_file.endswith("crai") and 'cram##idx##' in alignment_filename):
+        print("@@2 opening cram based on filenames")
         return pysam.AlignmentFile(
             alignment_file, "rc", reference_filename=reference_fasta, index_filename=index_filename
         )

--- a/depth_calling/utilities.py
+++ b/depth_calling/utilities.py
@@ -51,7 +51,19 @@ def parse_gmm_file(gmm_file):
 
 
 def open_alignment_file(alignment_file, reference_fasta=None, index_filename=None):
-    if alignment_file.endswith("cram"):
+
+    if isinstance(alignment_file, pysam.AlignmentFile):
+        if reference_fasta:
+            print("was I supposed to assign the reference? oops!")
+        if index_filename:
+            if alignment_file.has_index():
+                existing = alignment_file.index_filename
+                if index_filename != existing:
+                    print("was I supposed to assign the index? oops! I don't do that ... yet?")
+            else:
+                print("was I supposed to assign the index? oops! I don't do that ... yet?")
+        return alignment_file
+    elif alignment_file.endswith("cram"):
         return pysam.AlignmentFile(
             alignment_file, "rc", reference_filename=reference_fasta, index_filename=index_filename
         )

--- a/star_caller.py
+++ b/star_caller.py
@@ -169,11 +169,12 @@ def d6_star_caller(
         reads = bamfile.fetch()
         read_length = get_read_length(reads)
         normalized_depth = get_normed_depth_from_count(
-            count_file, call_parameters.region_dic, read_length
+            count_file, call_parameters.region_dic, read_length, index_filename=index_name
         )
     else:
         normalized_depth = get_normed_depth(
-            bam, call_parameters.region_dic, threads, reference=reference_fasta
+            bamfile, call_parameters.region_dic, threads, reference=reference_fasta,
+            index_filename=index_name,
         )
 
     # no-call after normalizaton


### PR DESCRIPTION
`get_normed_depth_from_count` & `get_normed_depth` are now able to accept inputs where the index is not in the same parent folder.

`open_alignment_file` can also now accept being passed an existing `pysam.AlignmentFile` instead of a string filepath.